### PR TITLE
Add gmail.org archive search box for mailing list

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -267,7 +267,8 @@ article p,
 article ul,
 article ol,
 article pre,
-article dl {
+article dl,
+article form {
 	font-size: 1.6em /* 16px */;
 	line-height: 1.375em /* 22px */;
 	margin-bottom: 1em;

--- a/index.html
+++ b/index.html
@@ -121,7 +121,16 @@ ann.setupPlugins()</code></pre>
             <li><strong>Write a plugin:</strong> If you’ve written a plugin, chances are your code will be useful to others. Please add a link to the wiki so people can find your stuff.</li>
             <!-- <li>If you want to learn more about developing your own plugin, please read our documentation about plugin development.</li> -->
           </ul>
-          <p>If you’re interested in our community, or you’re having trouble with something, please <a href="https://lists.okfn.org/mailman/listinfo/annotator-dev">join our mailing list</a>.</p>
+          <p>If you’re interested in our community, or you’re having trouble with something, please <a href="https://lists.okfn.org/mailman/listinfo/annotator-dev">join our mailing list</a>.
+          <form action="http://search.gmane.org/" class="form-inline">
+            <input name="group" value="gmane.comp.web.annotator" type="hidden">
+            <div class="form-group">
+              <div class="input-group">
+                <label for="query" class="input-group-addon">Search (via <a href="http://dir.gmane.org/gmane.comp.web.annotator">gmane</a>):</label>
+                <input name="query" size="30" type="text" class="form-control" />
+              </div>
+            </div>
+          </form></p>
         </div>
         <div class="col-lg-6">
           <h2 class="develop">Who is using it?</h2>

--- a/releases/index.html
+++ b/releases/index.html
@@ -1,0 +1,18 @@
+---
+layout: default
+---
+
+<div class="home">
+
+  <ul class="posts">
+    {% for post in site.posts %}
+      <li>
+        <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+        <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+
+  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+
+</div>


### PR DESCRIPTION
Fixes #10.

Leaves the link to the canonical source intact, but adds a gmail.org search box.

Hope that's copacetic. :wink:
