### PR TITLE
Make 2.x link go to the right place

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
           <p>
             Download:
             <a class="btn btn-success btn-lg" href="https://github.com/openannotation/annotator/releases/latest"><strong>1.2.x</strong> stable</a>
-            <a class="btn btn-warning btn-lg" href="https://github.com/openannotation/annotator/releases/latest"><strong>2.x</strong> pre-release</a>
+            <a class="btn btn-warning btn-lg" href="https://github.com/openannotation/annotator/releases"><strong>2.x</strong> pre-release</a>
             <a class="btn btn-default btn-lg" href="https://github.com/openannotation/annotator/">GitHub</a>
           </p>
         </div>


### PR DESCRIPTION
Forgot to change the link post-copy/paste.

My bad.
