### PR TITLE
Add Factlink/annotator-paragraph-icons to plugin list

### DIFF
--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -1,5 +1,14 @@
 [
 {
+    "name": "Paragraph icons for Annotator.js",
+    "description": "An icon next to each paragraph, that matches the text style. Makes annotation easier to discover.",
+    "owner": "Factlink",
+    "url": "https://github.com/Factlink/annotator-paragraph-icons",
+    "license": "MIT",
+    "tags": ["UI"],
+    "for": ["2.0.x"]
+},
+{
     "name": "Symfony - PageAnnotatorBundle",
     "description": "Symfony Bundle using AnnotatorJs. Store Plugin implemented and it lets you annotate with fixed values.",
     "owner": "Luca Perico",


### PR DESCRIPTION
I don't know if this is the right place to add 2.0.x plugins (since I don't see any other), but it seems useful to add our plugin to this list.
